### PR TITLE
WaRP7: proper fix when building meta-toolchain-qt5

### DIFF
--- a/conf/distro/warp7.conf
+++ b/conf/distro/warp7.conf
@@ -16,3 +16,5 @@ PREFERRED_PROVIDER_u-boot-fw-utils = "u-boot-fslc-fw-utils"
 
 PREFERRED_VERSION_swupdate = "git"
 
+# Fix : conflicts between attempted installs of nativesdk-cmake-3.7.2-r0.x86_64_nativesdk and nativesdk-qtbase-tools-5.8.0+git0+49dc9aa409-r0.x86_64_nativesdk
+DIRFILES_pn-nativesdk-cmake = "1"


### PR DESCRIPTION
Avoid this issue:

file /opt/warp7/2.3.2/sysroots/x86_64-warp7sdk-linux/environment-setup.d conflicts between attempted installs of nativesdk-cmake-3.7.2-r0.x86_64_nativesdk and nativesdk-qtbase-tools-5.8.0+git0+49dc9aa409-r0.x86_64_nativesdk

Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>