### PR TITLE
[meta-warp7-distro] : Fix some issues

### DIFF
--- a/conf/distro/warp7.conf
+++ b/conf/distro/warp7.conf
@@ -13,6 +13,8 @@ DISTRO_FEATURES_remove ?= "wayland x11"
 PREFERRED_PROVIDER_jpeg = "jpeg"
 PREFERRED_PROVIDER_jpeg-native = "jpeg-native"
 PREFERRED_PROVIDER_u-boot-fw-utils = "u-boot-fslc-fw-utils"
+	
+KERNEL_DEVICETREE += "imx7s-warp-modbus.dtb imx7s-warp-m4.dtb"	
 
 PREFERRED_VERSION_swupdate = "git"
 

--- a/recipes-kernel/linux/linux-warp7_%.bbappend
+++ b/recipes-kernel/linux/linux-warp7_%.bbappend
@@ -8,9 +8,3 @@ SRC_URI_append_imx7s-warp += " \
 	file://0005-Add-m4-support-and-modbus-example.patch \
 	file://ARM-imx-Add-imx7s-warp-RPMsg-support.patch \
 	"
-	
-KERNEL_DEVICETREE = " \
-		imx7s-warp.dtb \
-		imx7s-warp-modbus.dtb \
-		imx7s-warp-m4.dtb \
-		"	

--- a/recipes-warp7/hologram-tools/hologram-tools_git.bb
+++ b/recipes-warp7/hologram-tools/hologram-tools_git.bb
@@ -7,7 +7,7 @@ SRC_URI = " \
 	file://0001-change-baudrate-according-to-3G-SARA-Click.patch \
 "
 
-SRCREV = "${AUTOREV}"
+SRCREV = "8593eabcffd1ed629dcf74ca7149460048f7d48d"
 S = "${WORKDIR}/git"
 
 do_configure[noexec] = "1"


### PR DESCRIPTION
- Now KERNEL_DEVICETREE is defined in warp7.conf
- Fix an SRCREV for hologram-tools recipe