### PR TITLE
warp7.conf: do not install zImage into rootfs

### DIFF
--- a/conf/distro/warp7.conf
+++ b/conf/distro/warp7.conf
@@ -20,3 +20,6 @@ PREFERRED_VERSION_swupdate = "git"
 
 # Fix : conflicts between attempted installs of nativesdk-cmake-3.7.2-r0.x86_64_nativesdk and nativesdk-qtbase-tools-5.8.0+git0+49dc9aa409-r0.x86_64_nativesdk
 DIRFILES_pn-nativesdk-cmake = "1"
+
+# The kernel image is installed into the boot partition not need to install it in /boot
+RDEPENDS_kernel-base = ""


### PR DESCRIPTION
Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>