### PR TITLE
packagegroup: not need to install Qt app's

### DIFF
--- a/recipes-warp7/packagegroups/packagegroup-tools-io.bb
+++ b/recipes-warp7/packagegroups/packagegroup-tools-io.bb
@@ -9,7 +9,5 @@ RDEPENDS_${PN} = " \
     	devmem2 \
     	evtest \
     	spitools \
-    	modbus-rtu \
-	service-mpl3115 \
 	rpmsg-tools \
     "


### PR DESCRIPTION
- remove modbus-rtu
- remove service-mpl3115

Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>