### PR TITLE
mender: Update systemd service to start after network-online

### DIFF
--- a/recipes-mender/mender/files/mender.service
+++ b/recipes-mender/mender/files/mender.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Mender OTA update service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=idle
+User=root
+Group=root
+ExecStartPre=/bin/mkdir -p -m 0700 /data/mender
+ExecStartPre=/bin/ln -sf /etc/mender/tenant.conf /var/lib/mender/authtentoken
+ExecStart=/usr/bin/mender -daemon
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-mender/mender/mender_%.bbappend
+++ b/recipes-mender/mender/mender_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"


### PR DESCRIPTION
Update the service provided by Mender (the default one)
by starting only once the network is up.

Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>