### PR TITLE
kernel/linux-warp7: enable Namespaces support

### DIFF
--- a/recipes-kernel/linux/linux-warp7_%.bbappend
+++ b/recipes-kernel/linux/linux-warp7_%.bbappend
@@ -34,4 +34,7 @@ kernel_do_configure_prepend() {
     #IIO interrupt and sysfs triggers
     kernel_conf_variable IIO_INTERRUPT_TRIGGER y
     kernel_conf_variable IIO_SYSFS_TRIGGER y
+
+    #Namespaces support
+    kernel_conf_variable NAMESPACES	y
 }


### PR DESCRIPTION
To avoid:

[FAILED] Failed to start Hostname Service.

Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>