### PR TITLE
kernel/linux-warp7: added bcmdhd in KERNEL_MODULE_AUTOLOAD

### DIFF
--- a/recipes-kernel/linux/linux-warp7_%.bbappend
+++ b/recipes-kernel/linux/linux-warp7_%.bbappend
@@ -38,3 +38,7 @@ kernel_do_configure_prepend() {
     #Namespaces support
     kernel_conf_variable NAMESPACES	y
 }
+
+KERNEL_MODULE_AUTOLOAD += " \
+	${@bb.utils.contains('MACHINE_FEATURES', 'wifi', 'bcmdhd', '',d)} \
+"


### PR DESCRIPTION
Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>